### PR TITLE
Fixing bugs, improving behavior…

### DIFF
--- a/autoload/emoji_complete.vim
+++ b/autoload/emoji_complete.vim
@@ -38,15 +38,23 @@ func! emoji_complete#complete()
     return ""
   endif
   call s:init_emojis_once()
-  let line = getline('.')[ : col('.')-1]
-  let s:complete_start = match(line, '\w*$')
+  " The text from the beginning of the line up until before the cursor.
+  let line = getline('.')[ : col('.')-2]
+  let s:complete_start = match(line, '\(-1\|+1\|[-a-zA-Z0-9_]*\)$')
   if s:complete_start >= 0
     augroup emoji_complete_done
       au!
       au CompleteDone <buffer> call s:emoji_expand()
     augroup end
-    call complete( s:complete_start+1, s:emojis )
-    return "\<c-p>"
+    let prefix = line[s:complete_start : ]
+    let matches = []
+    for emoji in s:emojis
+      if emoji['word'] =~? '^' . prefix
+        call add( matches, emoji )
+      endif
+    endfor
+    call complete( s:complete_start+1, matches )
+    return ""
   endif
   return ""
 endfunc


### PR DESCRIPTION
* Correctly get the preceding text by using `col('.')-2` instead of `col('.')-1`. This was written correctly in `s:emoji_expand()`, but was incorrect/buggy in `emoji_complete#complete()`.

* Improving the regular expression to match any possible alias.

* Filters the auto-complete list upon first execution. This is the expected behavior, because that's how the other completions also work.

* Avoid executing `<C-P>` after first execution. This also mimics the behavior of other completions.